### PR TITLE
Fix vtu_port_size

### DIFF
--- a/mv88e6xxx_dump.c
+++ b/mv88e6xxx_dump.c
@@ -1528,13 +1528,16 @@ static void cmd_vtu(struct mv88e6xxx_ctx *ctx)
 	if (err)
 		return;
 
-	ctx->vtu_port_size = 8; /* default */
+	/* Only MV88E6XXX_FAMILY_639{0,3} use 8, set default to 4 */
+	ctx->vtu_port_size = 4;
 
 	switch (ctx->chip) {
+	/* MV88E6XXX_FAMILY_6390 */
 	case MV88E6190:
 	case MV88E6191:
 	case MV88E6290:
 	case MV88E6390:
+		ctx->vtu_port_size = 8;
 		return vtu_mv88e6xxx(ctx, 0x7ff);
 	case MV88E6171:
 	case MV88E6175:
@@ -1554,7 +1557,6 @@ static void cmd_vtu(struct mv88e6xxx_ctx *ctx)
 	case MV88E6071:
 	case MV88E6220:
 	case MV88E6250:
-		ctx->vtu_port_size = 4;
 		return vtu_mv88e6xxx(ctx, 0x3f);
 	case MV88E6131:
 	case MV88E6185:


### PR DESCRIPTION
This was only validated with MV88E6176 / Turris Omnia

before:
```
root@turris:~# mv88e6xxx_dump --vtu
Using device <mdio_bus/f1072004.mdio-mii:10>
VTU:
	V - a member, egress not modified
	U - a member, egress untagged
	T - a member, egress tagged
	X - not a member, Ingress frames with VID discarded
P  VID 0123456  FID  SID QPrio FPrio VidPolicy
0    1 XVXVXVX    1    0     -     -     0  
0    2 XVXVXVX    6    0     -     -     0  
0    3 XVXVXVU    5    0     -     -     0  
0    4 XVXVUVX    4    0     -     -     0  
0    5 XVUVXVX    3    0     -     -     0  
0    6 UVXVXVX    2    0     -     -     0  
```

after:
```
root@turris:/tmp# ./mv88e6xxx_dump --vtu
Using device <mdio_bus/f1072004.mdio-mii:10>
VTU:
	V - a member, egress not modified
	U - a member, egress untagged
	T - a member, egress tagged
	X - not a member, Ingress frames with VID discarded
P  VID 0123456  FID  SID QPrio FPrio VidPolicy
0    1 XXXXXVV    1    0     -     -     0  
0    2 XXXXUVV    6    0     -     -     0  
0    3 XXXUXVV    5    0     -     -     0  
0    4 XXUXXVV    4    0     -     -     0  
0    5 XUXXXVV    3    0     -     -     0  
0    6 UXXXXVV    2    0     -     -     0  
```