### PR TITLE
Adapt tool to work with kernels post-v6.2

### DIFF
--- a/mv88e6xxx_dump.c
+++ b/mv88e6xxx_dump.c
@@ -2043,7 +2043,8 @@ static int get_info_cb(const struct nlmsghdr *nlh, void *data)
 		return MNL_CB_ERROR;
 
 	driver_name = mnl_attr_get_str(tb[DEVLINK_ATTR_INFO_DRIVER_NAME]);
-	if (strcmp(driver_name, "mv88e6xxx")) {
+	if (strcmp(driver_name, "mv88e6xxx") &&
+	    strcmp(driver_name, "mv88e6085")) {
 		printf("%s/%s is not an mv88e6xxx\n", ctx->bus_name,
 			ctx->dev_name);
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
Kernel commit 226bf9805506 ("net: devlink: let the core report the driver name instead of the drivers") has caused a functional change for the mv88e6xxx driver, where the DEVLINK_ATTR_INFO_DRIVER_NAME netlink attribute stopped reporting "mv88e6xxx" and started reporting "mv88e6085".

The easiest way to go about this seems to be to patch the program to accept both driver names.